### PR TITLE
Docker Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Drone Fly uses the Jib plugin which will build a docker image during the `packag
 	docker run --env APIARY_BOOTSTRAPSERVERS="localhost:9092" \
 			   --env APIARY_LISTENER_LIST="com.expediagroup.sampleListener1,com.expediagroup.sampleListener2" \
 			   --env APIARY_KAFKA_TOPICNAME="dronefly" \
-			   -it expediagroup/drone-fly-app:<image-version>
+			   expediagroup/drone-fly-app:<image-version>
 	
 The properties `apiary.bootstrapservers`, `apiary.kafka.topicname` and `apiary.listener.list` can also be provided in the spring properties file.
 	

--- a/README.md
+++ b/README.md
@@ -26,13 +26,23 @@ The Drone Fly image will be used as a base image by downstream projects which ne
 
 Drone Fly uses the Jib plugin which will build a docker image during the `package` phase. The image can also be built directly:
 
-    mvn compile com.google.cloud.tools:jib-maven-plugin:dockerBuild -pl drone-fly-app
+    mvn compile jib:dockerBuild -pl drone-fly-app
     
 # Running DroneFly
 
-	java -Dloader.path=lib/ -jar drone-fly-app-<version>-exec.jar --apiary.bootstrapservers=localhost:9092 --apiary.kafka.topicname=apiary
+	java -Dloader.path=lib/ -jar drone-fly-app-<version>-exec.jar \
+		--apiary.bootstrapservers=localhost:9092 \
+		--apiary.kafka.topicname=apiary \
+		--apiary.listener.list="com.expediagroup.sampleListener1,com.expediagroup.sampleListener2"
 	
-The properties `apiary.bootstrapservers` and `apiary.kafka.topicname` can also be provided in the spring properties file.
+# Running DroneFly Docker image
+
+	docker run --env APIARY_BOOTSTRAPSERVERS="localhost:9092" \
+			   --env APIARY_LISTENER_LIST="com.expediagroup.sampleListener1,com.expediagroup.sampleListener2" \
+			   --env APIARY_KAFKA_TOPICNAME="dronefly" \
+			   -it expediagroup/drone-fly-app:<image-version>
+	
+The properties `apiary.bootstrapservers`, `apiary.kafka.topicname` and `apiary.listener.list` can also be provided in the spring properties file.
 	
 	java -Dloader.path=lib/ -jar drone-fly-app-<version>-exec.jar --spring.config.location=file:///dronefly.properties
 
@@ -40,4 +50,5 @@ The properties `apiary.bootstrapservers` and `apiary.kafka.topicname` can also b
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 Copyright 2020 Expedia, Inc.
+
 

--- a/drone-fly-app/pom.xml
+++ b/drone-fly-app/pom.xml
@@ -14,6 +14,7 @@
     <aws.version>1.11.532</aws.version>
     <s3mock.version>0.2.5</s3mock.version>
     <hive.version>2.3.7</hive.version>
+    <docker.container.port>8008</docker.container.port>
   </properties>
 
   <dependencies>

--- a/drone-fly-app/pom.xml
+++ b/drone-fly-app/pom.xml
@@ -66,6 +66,10 @@
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/drone-fly-app/src/main/scripts/startup.sh
+++ b/drone-fly-app/src/main/scripts/startup.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [[ ! -z $DRONEFLY_CONFIG ]]; then
-  echo "$DRONEFLY_CONFIG"|base64 -d > ./conf/dronefly-config.yml
-  java -Dloader.path=/app/lib/ -jar /app/libs/drone-fly-app-$APP_VERSION-exec.jar --config=./conf/dronefly-config.yml
-else
-  java -Dloader.path=/app/lib/ -jar /app/libs/drone-fly-app-$APP_VERSION-exec.jar --apiary.bootstrapservers=$KAFKA_BOOTSTRAP_SERVERS --apiary.kafka.topicname=$KAFKA_TOPIC_NAME
-fi

--- a/drone-fly-app/src/main/scripts/startup.sh
+++ b/drone-fly-app/src/main/scripts/startup.sh
@@ -1,0 +1,6 @@
+if [[ ! -z $DRONEFLY_CONFIG ]]; then
+  echo "$DRONEFLY_CONFIG"|base64 -d > ./conf/dronefly-config.yml
+  java -Dloader.path=/app/lib/ -jar /app/libs/drone-fly-app-$APP_VERSION-exec.jar --config=./conf/dronefly-config.yml
+else
+  java -Dloader.path=/app/lib/ -jar /app/libs/drone-fly-app-$APP_VERSION-exec.jar --apiary.bootstrapservers=$KAFKA_BOOTSTRAP_SERVERS --apiary.kafka.topicname=$KAFKA_TOPIC_NAME
+fi

--- a/drone-fly-app/src/main/scripts/startup.sh
+++ b/drone-fly-app/src/main/scripts/startup.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [[ ! -z $DRONEFLY_CONFIG ]]; then
   echo "$DRONEFLY_CONFIG"|base64 -d > ./conf/dronefly-config.yml
   java -Dloader.path=/app/lib/ -jar /app/libs/drone-fly-app-$APP_VERSION-exec.jar --config=./conf/dronefly-config.yml

--- a/pom.xml
+++ b/pom.xml
@@ -144,25 +144,10 @@
             </to>
             <container>
               <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
-              <entrypoint>/bin/startup.sh</entrypoint>
-              <!-- <ports>
+              <ports>
                 <port>${docker.container.port}</port>
-                </ports> -->
+              </ports>
             </container>
-            <extraDirectories>
-              <paths>
-                <path>
-                  <from>./src/main/scripts</from>
-                  <into>/bin</into>
-                </path>
-              </paths>
-              <permissions>
-                <permission>
-                  <file>/bin/startup.sh</file>
-                  <mode>755</mode>
-                </permission>
-              </permissions>
-            </extraDirectories>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,14 @@
     <logback.version>1.2.3</logback.version>
     <maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
     <jib.maven.plugin.version>2.4.0</jib.maven.plugin.version>
+    <docker.from.image>openjdk</docker.from.image>
+    <docker.from.tag>8-jdk</docker.from.tag>
+    <docker.from.reference>${docker.from.image}:${docker.from.tag}</docker.from.reference>
+    <docker.registry>expediagroup</docker.registry>
+    <docker.to.image>${project.artifactId}</docker.to.image>
+    <docker.to.reference>${dockerhub.url}/${docker.registry}/${docker.to.image}:${docker.to.tag}</docker.to.reference>
+    <docker.to.tag>${project.version}</docker.to.tag>
+    <dockerhub.url>docker.io</dockerhub.url>
   </properties>
 
   <dependencyManagement>
@@ -104,14 +112,63 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>${maven.shade.plugin.version}</version>
-        </plugin>
-        <plugin>
           <groupId>com.google.cloud.tools</groupId>
           <artifactId>jib-maven-plugin</artifactId>
           <version>${jib.maven.plugin.version}</version>
+          <executions>
+            <execution>
+              <id>deploy</id>
+              <phase>deploy</phase>
+              <goals>
+                <goal>build</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>package</id>
+              <phase>package</phase>
+              <goals>
+                <goal>dockerBuild</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <from>
+              <image>${docker.from.reference}</image>
+            </from>
+            <to>
+              <image>${docker.to.reference}</image>
+              <auth>
+                <username>${DOCKERHUB_USERNAME}</username>
+                <password>${DOCKERHUB_PASSWORD}</password>
+              </auth>
+            </to>
+            <container>
+              <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
+              <entrypoint>/bin/startup.sh</entrypoint>
+              <!-- <ports>
+                <port>${docker.container.port}</port>
+                </ports> -->
+            </container>
+            <extraDirectories>
+              <paths>
+                <path>
+                  <from>./src/main/scripts</from>
+                  <into>/bin</into>
+                </path>
+              </paths>
+              <permissions>
+                <permission>
+                  <file>/bin/startup.sh</file>
+                  <mode>755</mode>
+                </permission>
+              </permissions>
+            </extraDirectories>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${maven.shade.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>com.mycila</groupId>


### PR DESCRIPTION
These changes create a docker image with name "drone-fly-app" and pushes it to docker hub.

Entry point of the image is set as: 
```
java, -cp, /app/resources:/app/classes:/app/libs/*, com.expediagroup.dataplatform.dronefly.app.DroneFly
```

Now, the build produces an uber jar as well as a docker image that has just classes in it.

**Plan:**
This image will act as base image and when we want to deploy a new listener, we will need to build that image on top of this where we add the listener's jar to /app/lib folder that is already in the classpath.

I will add all these details in the README once I get it all running.