### PR TITLE
feat: adding config properties map for kafka consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2024-10-24
+### Added
+* Support for consumer properties allowing connecting to Kafka cloud provider.
+
 ## [1.0.0] - 2023-04-27
 ### Changed
 * Upgrade `Springboot` version from `2.3.3.RELEASE` to `2.7.10`.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,26 @@ The table below describes all the available configuration values for Drone Fly.
 | instance.name | Instance name for a Drone Fly instance. `instance.name` is also used to derive the Kafka consumer group. Therefore, in a multi-instance deployment, a unique `instance.name` for each Drone Fly instance needs to be provided to avoid all instances ending up in the same Kafka consumer group. | `string` | `drone-fly` | no |
 | endpoint.port | Port on which Drone Fly Spring Boot app will start. | `string` | `8008` | no |
 
+### Additional configuration parameters
+The Kafka message reader supports client properties that are passed to the Kafka consumer builder.
+These are environment variables with the PREFIX apiary.messaging.client.
+
+ #### Example for sending client parameters when using a Kafka cloud provider
+- apiary.messaging.client.security.protocol=SSL
+- apiary.messaging.client.sasl.mechanism=AWS_MSK_IAM
+- apiary.messaging.client.sasl_jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required;
+- apiary.messaging.client.sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler
+
+In this case we are sending the properties to Kafka's consumer to be able to connect to AWS MSK which also requires the IAM library included as a dependency in the POM.xml file
+
+	java -Dloader.path=lib/ -jar drone-fly-app-<version>-exec.jar \
+		--apiary.bootstrap.servers=localhost:9092 \
+		--apiary.kafka.topic.name=apiary \
+		--apiary.listener.list="com.expediagroup.sampleListener1,com.expediagroup.sampleListener2" \
+        --apiary.messaging.client.security.protocol=SSL \
+        --apiary.messaging.client.sasl.mechanism=AWS_MSK_IAM \
+        --apiary.messaging.client.sasl_jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required; \
+        --apiary.messaging.client.sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler
 
 ## Metrics
 

--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ The table below describes all the available configuration values for Drone Fly.
 | endpoint.port | Port on which Drone Fly Spring Boot app will start. | `string` | `8008` | no |
 
 ### Additional configuration parameters
-The Kafka message reader supports client properties that are passed to the Kafka consumer builder.
-These are environment variables with the PREFIX apiary.messaging.client.
+The Kafka message reader supports properties that are passed to the Kafka consumer builder.
+These are environment variables with the PREFIX apiary.messaging.consumer.
 
- #### Example for sending client parameters when using a Kafka cloud provider
-- apiary.messaging.client.security.protocol=SSL
-- apiary.messaging.client.sasl.mechanism=AWS_MSK_IAM
-- apiary.messaging.client.sasl_jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required;
-- apiary.messaging.client.sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler
+ #### Example for sending consumer parameters when using a Kafka cloud provider
+- apiary.messaging.consumer.security.protocol=SSL
+- apiary.messaging.consumer.sasl.mechanism=AWS_MSK_IAM
+- apiary.messaging.consumer.sasl_jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required;
+- apiary.messaging.consumer.sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler
 
 In this case we are sending the properties to Kafka's consumer to be able to connect to AWS MSK which also requires the IAM library included as a dependency in the POM.xml file
 
@@ -106,10 +106,10 @@ In this case we are sending the properties to Kafka's consumer to be able to con
 		--apiary.bootstrap.servers=localhost:9092 \
 		--apiary.kafka.topic.name=apiary \
 		--apiary.listener.list="com.expediagroup.sampleListener1,com.expediagroup.sampleListener2" \
-        --apiary.messaging.client.security.protocol=SSL \
-        --apiary.messaging.client.sasl.mechanism=AWS_MSK_IAM \
-        --apiary.messaging.client.sasl_jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required; \
-        --apiary.messaging.client.sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler
+        --apiary.messaging.consumer.security.protocol=SSL \
+        --apiary.messaging.consumer.sasl.mechanism=AWS_MSK_IAM \
+        --apiary.messaging.consumer.sasl_jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required; \
+        --apiary.messaging.consumer.sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler
 
 ## Metrics
 

--- a/drone-fly-app/pom.xml
+++ b/drone-fly-app/pom.xml
@@ -108,6 +108,13 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/software.amazon.msk/aws-msk-iam-auth -->
+    <dependency>
+      <groupId>software.amazon.msk</groupId>
+      <artifactId>aws-msk-iam-auth</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/drone-fly-app/pom.xml
+++ b/drone-fly-app/pom.xml
@@ -108,13 +108,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/software.amazon.msk/aws-msk-iam-auth -->
     <dependency>
       <groupId>software.amazon.msk</groupId>
       <artifactId>aws-msk-iam-auth</artifactId>
       <version>1.1.1</version>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/drone-fly-app/src/main/java/com/expediagroup/dataplatform/dronefly/app/context/CommonBeans.java
+++ b/drone-fly-app/src/main/java/com/expediagroup/dataplatform/dronefly/app/context/CommonBeans.java
@@ -16,6 +16,7 @@
 package com.expediagroup.dataplatform.dronefly.app.context;
 
 import java.util.List;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -65,7 +66,16 @@ public class CommonBeans {
 
   @Bean
   public MessageReaderAdapter messageReaderAdapter() {
-    KafkaMessageReader delegate = KafkaMessageReaderBuilder.builder(bootstrapServers, topicName, instanceName).build();
+    Properties mskProperties = new Properties();
+    mskProperties.put("security.protocol", "SSL");
+    mskProperties.put("sasl.mechanism", "AWS_MSK_IAM");
+    mskProperties.put("sasl.jaas.config", "software.amazon.msk.auth.iam.IAMLoginModule required;");
+    mskProperties.put("sasl.client.callback.handler.class", "software.amazon.msk.auth.iam.IAMClientCallbackHandler");
+
+    KafkaMessageReader delegate = KafkaMessageReaderBuilder.
+            builder(bootstrapServers, topicName, instanceName).
+            withConsumerProperties(mskProperties).
+            build();
     return new MessageReaderAdapter(delegate);
   }
 

--- a/drone-fly-app/src/main/java/com/expediagroup/dataplatform/dronefly/app/context/CommonBeans.java
+++ b/drone-fly-app/src/main/java/com/expediagroup/dataplatform/dronefly/app/context/CommonBeans.java
@@ -76,10 +76,10 @@ public class CommonBeans {
 
   @Bean
   public MessageReaderAdapter messageReaderAdapter() {
-    Properties clientProperties = getConsumerProperties();
+    Properties consumerProperties = getConsumerProperties();
     KafkaMessageReader delegate = KafkaMessageReaderBuilder.
             builder(bootstrapServers, topicName, instanceName).
-            withConsumerProperties(clientProperties).
+            withConsumerProperties(consumerProperties).
             build();
     return new MessageReaderAdapter(delegate);
   }
@@ -88,7 +88,7 @@ public class CommonBeans {
     Properties consumerProperties = new Properties();
     getEnvProperties().forEach((key, value) -> {
         consumerProperties.put(key.toString(), value.toString());
-        log.info("Client property {} set with value: {}", key, value);
+        log.info("Consumer property {} set with value: {}", key, value);
     } );
     return consumerProperties;
   }

--- a/drone-fly-app/src/main/java/com/expediagroup/dataplatform/dronefly/app/context/CommonBeans.java
+++ b/drone-fly-app/src/main/java/com/expediagroup/dataplatform/dronefly/app/context/CommonBeans.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.MetaStoreEventListener;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -40,7 +39,7 @@ import org.springframework.context.annotation.Primary;
 @Configuration
 public class CommonBeans {
   private static final Logger log = LoggerFactory.getLogger(CommonBeans.class);
-  public static final String PREFIX = "apiary.messaging.client.";
+  public static final String CONSUMER_PROPERTIES_PREFIX = "apiary.messaging.consumer";
 
   @Value("${instance.name:drone-fly}")
   private String instanceName;
@@ -61,7 +60,7 @@ public class CommonBeans {
 
   @Bean
   @Primary
-  @ConfigurationProperties
+  @ConfigurationProperties(CONSUMER_PROPERTIES_PREFIX)
   public Properties getEnvProperties() {
     return new Properties();
   }
@@ -77,7 +76,7 @@ public class CommonBeans {
 
   @Bean
   public MessageReaderAdapter messageReaderAdapter() {
-    Properties clientProperties = getClientProperties();
+    Properties clientProperties = getConsumerProperties();
     KafkaMessageReader delegate = KafkaMessageReaderBuilder.
             builder(bootstrapServers, topicName, instanceName).
             withConsumerProperties(clientProperties).
@@ -85,16 +84,13 @@ public class CommonBeans {
     return new MessageReaderAdapter(delegate);
   }
 
-  private Properties getClientProperties() {
-    Properties clientProperties = new Properties();
+  private Properties getConsumerProperties() {
+    Properties consumerProperties = new Properties();
     getEnvProperties().forEach((key, value) -> {
-      if (key.toString().startsWith(PREFIX)) {
-        String keyWithoutPrefix = StringUtils.replace(key.toString(), PREFIX, "");
-        clientProperties.put(keyWithoutPrefix, value.toString());
-        log.info("Client property {} set with value: {}", keyWithoutPrefix, value);
-      }
+        consumerProperties.put(key.toString(), value.toString());
+        log.info("Client property {} set with value: {}", key, value);
     } );
-    return clientProperties;
+    return consumerProperties;
   }
 
 }

--- a/drone-fly-integration-tests/pom.xml
+++ b/drone-fly-integration-tests/pom.xml
@@ -76,5 +76,10 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.msk</groupId>
+      <artifactId>aws-msk-iam-auth</artifactId>
+      <version>1.1.1</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Added a config properties map for allowing sending those properties to kafka consumer, allowing us to connect to kafka cloud providers