### PR TITLE
test: add ApiaryGlueSync deployment smoke test

### DIFF
--- a/drone-fly-integration-tests/pom.xml
+++ b/drone-fly-integration-tests/pom.xml
@@ -11,6 +11,11 @@
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
 
+  <properties>
+    <!-- JaCoCo 0.8.13+ is required for Java 25 (class file major version 69) support -->
+    <jacoco.version>0.8.13</jacoco.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.expediagroup</groupId>
@@ -43,7 +48,7 @@
     <dependency>
       <groupId>com.expediagroup.apiary</groupId>
       <artifactId>kafka-metastore-listener</artifactId>
-      <version>8.1.15</version>
+      <version>8.1.18</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -103,5 +108,54 @@
       <version>${dropwizard.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.expediagroup.apiary</groupId>
+      <artifactId>apiary-gluesync-listener</artifactId>
+      <version>8.1.18</version>
+      <classifier>all</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-metastore</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>
+            @{argLine}
+            --add-opens java.base/java.lang=ALL-UNNAMED
+            --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+            --add-opens java.base/java.io=ALL-UNNAMED
+            --add-opens java.base/java.net=ALL-UNNAMED
+            --add-opens java.base/java.nio=ALL-UNNAMED
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+            --add-opens java.base/java.security=ALL-UNNAMED
+            -Dnet.bytebuddy.experimental=true
+          </argLine>
+          <!-- Fake region so AWSGlueClientBuilder.withRegion() doesn't NPE; fake creds so the
+               SDK credential chain doesn't try EC2 instance metadata and hang. The Glue API call
+               fails fast with an UnknownHostException (no real AWS endpoint at that region). -->
+          <environmentVariables>
+            <AWS_REGION>us-fake-1</AWS_REGION>
+            <AWS_ACCESS_KEY_ID>test</AWS_ACCESS_KEY_ID>
+            <AWS_SECRET_ACCESS_KEY>test</AWS_SECRET_ACCESS_KEY>
+          </environmentVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/drone-fly-integration-tests/src/test/java/com/expediagroup/dataplatform/dronefly/core/integration/ApiaryGlueSyncMetricsIntegrationTest.java
+++ b/drone-fly-integration-tests/src/test/java/com/expediagroup/dataplatform/dronefly/core/integration/ApiaryGlueSyncMetricsIntegrationTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2020-2026 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.dataplatform.dronefly.core.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import io.micrometer.core.instrument.Metrics;
+
+import com.expediagroup.dataplatform.dronefly.app.DroneFly;
+import com.expediagroup.dataplatform.dronefly.app.DroneFlyRunner;
+import com.expediagroup.dataplatform.dronefly.app.service.ListenerCatalog;
+
+/**
+ * Deployment smoke test for apiary-gluesync-listener inside a Dronefly Spring Boot context.
+ * Validates two things that cannot be covered in apiary-gluesync-listener without a circular
+ * dependency: (1) the fat jar loads without classpath conflicts, and (2) Prometheus is registered
+ * before ApiaryGlueSync is constructed so MetricService does not fall back to JMX.
+ */
+@SpringBootTest(
+    classes = DroneFly.class,
+    // RANDOM_PORT (not NONE) mirrors production: Dronefly always runs a web server, and the
+    // web server's dependency chain causes PrometheusMeterRegistry to initialise before
+    // ListenerCatalog — preventing the JmxMeterRegistry fallback in MetricService.
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "apiary.bootstrap.servers=localhost:9999",
+        "apiary.kafka.topic.name=test-topic",
+        "instance.name=test",
+        "apiary.listener.list=com.expediagroup.apiary.extensions.gluesync.listener.ApiaryGlueSync",
+        // Spring Boot test defaults disable metric export; re-enable so PrometheusMeterRegistry
+        // is added to Metrics.globalRegistry before ApiaryGlueSync is constructed.
+        "management.defaults.metrics.export.enabled=true",
+        "management.prometheus.metrics.export.enabled=true"
+    }
+)
+class ApiaryGlueSyncMetricsIntegrationTest {
+
+  @MockitoBean
+  DroneFlyRunner droneFlyRunner;
+
+  @Autowired
+  ListenerCatalog listenerCatalog;
+
+  /** Verifies the fat jar loaded cleanly and that Prometheus was registered before ApiaryGlueSync
+   *  was constructed — wrong bean ordering would silently add a JmxMeterRegistry instead. */
+  @Test
+  void listenerLoadedWithCorrectMetricRegistry() {
+    assertThat(listenerCatalog.getListeners())
+        .extracting(l -> l.getClass().getSimpleName())
+        .contains("ApiaryGlueSync");
+
+    assertThat(Metrics.globalRegistry.getRegistries())
+        .noneMatch(r -> r.getClass().getName().contains("JmxMeterRegistry"));
+  }
+}

--- a/drone-fly-integration-tests/src/test/java/com/expediagroup/dataplatform/dronefly/core/integration/DroneFlyIntegrationTestUtils.java
+++ b/drone-fly-integration-tests/src/test/java/com/expediagroup/dataplatform/dronefly/core/integration/DroneFlyIntegrationTestUtils.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 
@@ -41,7 +42,9 @@ public class DroneFlyIntegrationTestUtils {
     partitions.add(new FieldSchema("a", "string", "comment"));
     partitions.add(new FieldSchema("b", "string", "comment"));
     partitions.add(new FieldSchema("c", "string", "comment"));
-    return new Table(tableName, DATABASE, "me", 1, 1, 1, new StorageDescriptor(), partitions, buildTableParameters(),
+    StorageDescriptor sd = new StorageDescriptor();
+    sd.setSerdeInfo(new SerDeInfo("serde", "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe", new HashMap<>()));
+    return new Table(tableName, DATABASE, "me", 1, 1, 1, sd, partitions, buildTableParameters(),
         "originalText", "expandedText", "tableType");
   }
 

--- a/drone-fly-integration-tests/src/test/java/com/expediagroup/dataplatform/dronefly/core/integration/DummyListener.java
+++ b/drone-fly-integration-tests/src/test/java/com/expediagroup/dataplatform/dronefly/core/integration/DummyListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Expedia, Inc.
+ * Copyright (C) 2020-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drone-fly-integration-tests/src/test/resources/log4j2.xml
+++ b/drone-fly-integration-tests/src/test/resources/log4j2.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2020 Expedia, Inc.
- 
+  Copyright (C) 2020-2026 Expedia, Inc.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
- 
+
   http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
  ## Summary                                                                                                                                                                        
                                                                                                                                                                                    
  - Adds `ApiaryGlueSyncMetricsIntegrationTest`, a `@SpringBootTest` smoke test that validates                                                                                      
    `apiary-gluesync-listener` deploys correctly inside a Dronefly Spring Boot context.                                                                                             
  - Bumps `kafka-metastore-listener` and `apiary-gluesync-listener` to `8.1.18` in the                                                                                              
    integration-tests POM, adding the `:all` (fat jar) classifier for gluesync.                                                                                                     
  - Adds `SerDeInfo` to `DroneFlyIntegrationTestUtils.buildTable()` to avoid an NPE in                                                                                              
    GlueSync's `HiveToGlueTransformer`.                                                                                                                                             
                                                                                                                                                                                    
  ## Why this test lives here                                                                                                                                                       
                                                                                                                                                                                    
  `apiary-gluesync-listener` cannot test its own behaviour inside a Dronefly Spring Boot                                                                                            
  context without depending on `drone-fly`, which would create a circular dependency.                                                                                               
  The test guards two things specific to the Dronefly deployment model:                                                                                                             
                                                                                                                                                                                    
  1. **Classpath integrity** — the `:all` fat jar (shaded AWS SDK + Dropwizard Metrics) loads                                                                                       
     without conflicts alongside Dronefly's own dependencies.                                                                                                                       
  2. **Bean-ordering invariant** — Spring Boot registers `PrometheusMeterRegistry` in                                                                                               
     `Metrics.globalRegistry` *before* `ApiaryGlueSync` is constructed. If that ordering                                                                                            
     were wrong, `ApiaryGlueSync.MetricService` silently falls back to adding a                                                                                                     
     `JmxMeterRegistry` and metrics never reach Prometheus.                                                                                                                         
                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                      
                                                                                                                                                                                    
  - [ ] `mvn -pl drone-fly-integration-tests -Dtest=ApiaryGlueSyncMetricsIntegrationTest test` passes locally                                                                       
  - [ ] CI green  

🤖 Generated with [Claude Code](https://claude.com/claude-code)